### PR TITLE
Update cartographer.md

### DIFF
--- a/docs/cartographer.md
+++ b/docs/cartographer.md
@@ -313,7 +313,8 @@ After the save config you have to do the touch calibration.
 1. Home All (`G28`)
 2. Run `_CALIBRATE_PRE_HEAT`, which will heat the bed to 60c, nozzle to 150c
 3. Run the `STOP_CAMERA` macro to stop the camera
-4. Run `CARTOGRAPHER_TOUCH_CALIBRATE SPEED=2`
+4. Run `SET_VELOCITY_LIMIT ACCEL=100`
+5. Run `CARTOGRAPHER_TOUCH_CALIBRATE SPEED=2`
    <br />Upon completion *`SAVE_CONFIG`*
 
 !!! warning
@@ -365,7 +366,8 @@ your bed mesh, so best to do it before.
 
 1. Home All (`G28`)
 2. Heat Nozzle to 150c (`M109 S150`) so that any filament can be removed from nozzle
-3. Run `CARTOGRAPHER_AXIS_TWIST_COMPENSATION`
+3. Run `SET_VELOCITY_LIMIT ACCEL=100`
+4. Run `CARTOGRAPHER_AXIS_TWIST_COMPENSATION`
    <br />Upon completion *`SAVE_CONFIG`*
 
 **Source:** <https://docs.cartographer3d.com/cartographer-probe/features/axis-twist-compensation>


### PR DESCRIPTION
<img width="502" height="435" alt="image" src="https://github.com/user-attachments/assets/dd1b0257-7429-471f-8417-8fe1210c65ee" />


so for 5.1.0 some users experience issues with probe triggered prior to movement errors the proposed changes hear makes users limit the accel so this error does not occur, the fix should be introduced by jomik in 1.1.0 but for now it is currently not implemented so user needs to manually specify `SET_VELOCITY_LIMIT ACCEL=100` so it does not cause errors