### PR TITLE
improve troubleshooting section

### DIFF
--- a/docs/cartographer_troubleshooting.md
+++ b/docs/cartographer_troubleshooting.md
@@ -18,6 +18,10 @@ If you get the following error, it means that the cartographer is not connected 
 
 ![image](assets/images/cartographer_protocol_error.png)
 
+!!! danger
+
+     If you are on V4 Cartographer Probe `cartographer:PA3` is not the right pin, you must use `cartographer:PA0`!  PA3 on V4 is used for something else, and will cause a potential boot loop of the probe causing the 'Unknown command: debug_read' error
+
 So from ssh run a `lsusb` and make sure you can see:
 
 ![image](assets/images/carto_lsusb.png)


### PR DESCRIPTION
added a danger section, can change to note if it would be better, to warn users, who use a v4 probe that having the adxl pin set to the v3 pin can and will cause boot loop issues which results in probe not connecting and causing the printer to throw the 'Unknown command: debug_read' error, thanks to TBK for pointing this out 
