### PR TITLE
Fix typo in cartographer_V4_flashing.md

### DIFF
--- a/docs/cartographer_V4_flashing.md
+++ b/docs/cartographer_V4_flashing.md
@@ -50,7 +50,7 @@ Klipper will not work with python 3.14 so we have to get python 3.12 installed v
 is even required, run `python3 --version`:
 
 ```
-$ python3 --version
+python3 --version
 Python 3.14.4
 ```
 


### PR DESCRIPTION
There was a typo with the python command showing $ python vs python so it wasn't able to be copy pasted user SickPup pointed out in discord thread